### PR TITLE
View progress as an individual or as a team (or your alt accounts)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { LadderData, ProblemStatusMap, UserData, UserStats } from './utils/types';
+import { Handle, LadderData, ProblemStatusMap, UserData, UserStats } from './utils/types';
 import httpClient from './utils/http';
 import { constants } from './utils/constants';
 
@@ -9,17 +9,19 @@ import Header from './components/Header';
 import Ladder from './components/Ladder';
 
 import LadderSelector from './components/LadderSelector';
-import { assignNewStatus, fetchUserSubmissionsWithRetry, getProblemID } from './utils/utils';
+import { aggregateRatings, assignNewStatus, fetchTeamSubmissions, fetchUserSubmissionsWithRetry, getProblemID, getUserRank } from './utils/utils';
 
 function App() {
 
 	const [user, setUser] = useState<string>('');
 	const [userErr, setUserErr] = useState<string>('');
 	const [userData, setUserData] = useState<UserData>(null);
+	const [teamData, setTeamData] = useState<UserData[]>([]);
 	const [userStats, setUserStats] = useState<UserStats>(null);
 	const [ladderData, setLadderData] = useState<LadderData>({ startRating: 1200, endRating: 1300 });
 	const [problemStatusMap, setProblemStatusMap] = useState<ProblemStatusMap>({});
 	const [fetchIntervalID, setfetchIntervalID] = useState<NodeJS.Timer | null>(null);
+	const [handleType, setHandleType] = useState<string>(Handle.INDIVIDUAL);
 
 	const loadUser = async () => {
 		try {
@@ -45,9 +47,62 @@ function App() {
 		}
 	}
 
+	const loadTeam = async () => {
+		const teamMembers = user.split(",");
+		const teamRatings: number[] = [];
+		const membersData = [];
+		const teamInfo = {
+			handle: "#team",
+			image: "",
+			maxRating: Number.MIN_SAFE_INTEGER,
+			rating: Number.MIN_SAFE_INTEGER,
+			rank: "",
+		};
+		for(let i = 0; i < teamMembers.length; i++) {
+			const member = teamMembers[i];
+			try {
+				const userDataRes = await httpClient.request({
+					method: 'GET',
+					url: `${constants.cfAPI}/user.info`,
+					params: {
+						handles: member,
+						lang: 'en',
+					},
+				});
+				const userInfo = userDataRes.result[0];
+				teamRatings.push(userInfo.rating);
+				teamInfo.maxRating = Math.max(teamInfo.maxRating, userInfo.maxRating);
+				teamInfo.image = userInfo.avatar;
+				membersData.push({
+					handle: userInfo.handle,
+					image: userInfo.avatar,
+					maxRating: userInfo.maxRating,
+					rating: userInfo.rating,
+					rank: userInfo.rank,
+				});
+				setUserErr('');
+			} catch (err: any) {
+				setUserErr(`Codeforces error: "${err.response.data.comment}"`);
+				break;
+			}
+		}
+		teamInfo.rating = aggregateRatings(teamRatings);
+		teamInfo.maxRating = Math.max(teamInfo.maxRating, teamInfo.rating);
+		teamInfo.rank = getUserRank(teamInfo.rating);
+		if(!userErr) {
+			setUserData(teamInfo);
+			setTeamData(membersData);
+		}
+	}
+
 	const updateProblemStatusMap = async (userData: UserData) => {
 		let newMap = {} as ProblemStatusMap;
-		const submissions = await fetchUserSubmissionsWithRetry(userData, 3);
+		let submissions = [];
+		if(handleType == Handle.INDIVIDUAL) {
+			submissions = await fetchUserSubmissionsWithRetry(userData, 3);
+		} else {
+			submissions = await fetchTeamSubmissions(teamData, 3);
+		}
 		for (const submission of submissions) {
 			const problem = { ...submission.problem };
 			const id = getProblemID(problem);
@@ -66,7 +121,7 @@ function App() {
 		const newFetchIntervalID = setInterval(() => updateProblemStatusMap(userData), constants.submissionFetchInterval);
 		setfetchIntervalID(newFetchIntervalID);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [userData]);
+	}, [userData, teamData]);
 
 	return (
 		<div className='container-fluid'>
@@ -74,16 +129,25 @@ function App() {
 
 			<div className="mb-3 row text-center justify-content-center">
 				<div className="col-auto">
+					<select className="form-select" defaultValue={handleType} onChange={(event)=>setHandleType(event.target.value)}>
+						<option value={Handle.INDIVIDUAL}>Individual</option>
+						<option value={Handle.TEAM}>Team</option>
+					</select>
+				</div>
+				<div className="col-auto">
 					<input type="text" placeholder="Search CF Handle" className="form-control" id="inputPassword"
 						value={user} onChange={(e) => setUser(e.target.value)} onKeyDown={(e) => {
 							if (e.key === 'Enter')
-								loadUser();
+								handleType==Handle.TEAM ? loadTeam() : loadUser();
 						}} />
 				</div>
 				<div className="col-auto">
-					<button className='btn btn-primary' onClick={loadUser}><i className="bi bi-search"></i> Search</button>
+					<button className='btn btn-primary' onClick={handleType==Handle.TEAM ? loadTeam : loadUser}><i className="bi bi-search"></i> Search</button>
 				</div>
 			</div>
+			{handleType==Handle.TEAM && <div className="mb-3 row text-center justify-content-center">
+				<p>**enter comma separated user handles of your team members</p>
+			</div>}
 			{userErr && <div className='row justify-content-center m-1 text-danger'>{userErr}</div>}
 			<UserCard userData={userData} userStats={userStats}/>
 			<LadderSelector startRating={900} endRating={3600} step={100} setLadderData={setLadderData} ladderData={ladderData}/>

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -40,4 +40,9 @@ export interface Problem {
 	status: ProblemStatus,
 }
 
+export enum Handle {
+	INDIVIDUAL = 'individual',
+	TEAM = 'team',
+}
+
 export type ProblemStatusMap = Record<string, ProblemStatus>;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -49,3 +49,45 @@ export const fetchUserSubmissions = async (user: UserData): Promise<any[]> => {
 	});
 	return response.result;
 }
+
+export const fetchTeamSubmissions = async (team: UserData[], retries: number): Promise<any[]>=> {
+	let ans: number[] = [];
+	for (const member of team) {
+		ans = ans.concat(await fetchUserSubmissionsWithRetry(member, retries));
+	}
+	return ans;
+}
+
+export const aggregateRatings = (teamRatings: number[]) => {
+	const getWinProbability = (ra: number, rb: number) => {
+		return 1.0 / (1.0 + Math.pow(10.0, (rb - ra) / 400.0));
+	}
+
+	let left = 1;
+    let right = 1E4;
+    for (let tt = 0; tt < 100; tt++) {
+        let r = (left + right) / 2.0;
+        let rWinsProbability = 1.0;
+        for(let i = 0; i < teamRatings.length; i++)
+            rWinsProbability *= getWinProbability(r, isNaN(teamRatings[i]) ? 0 : teamRatings[i]);
+        let rating = Math.log10(1 / (rWinsProbability) - 1) * 400 + r;
+        if (rating > r)
+            left = r;
+        else
+            right = r;
+    }
+    return Math.round((left + right) / 2.0);
+}
+
+export const getUserRank = (ratings: number): string => {
+	if(ratings < 1200)	return "newbie";
+	if(ratings < 1400)	return "pupil";
+	if(ratings < 1600)	return "specialist";
+	if(ratings < 1900)	return "expert";
+	if(ratings < 2100)	return "candidate master";
+	if(ratings < 2300)	return "master";
+	if(ratings < 2400)	return "international master";
+	if(ratings < 2600)	return "grandmaster";
+	if(ratings < 3000)	return "international grandmaster";
+	return "legendary grandmaster";
+}


### PR DESCRIPTION
Key changes:
1. Select tag having options as Individual(default) and Team.
2. When selected 'Individual', has the original functionality.
3. When selected 'Team', user has to enter the usernames(user-handles) of the team members separated by commas.
4. The team ratings is calculated as mentioned in: https://codeforces.com/blog/entry/16986 
5. The rating calculation of unrated and negatively rated accounts is not well handled, but it should not effect any functionality.

![individual_ss](https://user-images.githubusercontent.com/56225984/180494164-f9c1ff85-68a6-4454-97f6-cd6175d67a65.png)

![team_ss](https://user-images.githubusercontent.com/56225984/180494207-23fa592c-ee8e-4f2d-9f1f-1ab8e83deb1a.png)

